### PR TITLE
fix: custom.conf file by duplicate server_tokens

### DIFF
--- a/workshop/workshop-java-repo/.platform/nginx/conf.d/custom.conf
+++ b/workshop/workshop-java-repo/.platform/nginx/conf.d/custom.conf
@@ -1,2 +1,1 @@
 add_header X-Frame-Options SAMEORIGIN always;
-server_tokens off;


### PR DESCRIPTION
*[Issue #13 ](https://github.com/aws-samples/devsecops-cicd/issues/13)*

*Description of changes:*

Deleted "server_tokens" line from custom.conf file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
